### PR TITLE
Use array_key_exists

### DIFF
--- a/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
+++ b/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
@@ -75,7 +75,7 @@ abstract class AbstractOptionsProvider implements SelectOptionsProviderInterface
     protected function getConfiguration(string $name)
     {
         $configuration = $this->configuration ?: [];
-        return @$configuration[$name];
+        return array_key_exists($name, $configuration) ? $configuration[$name] : null;
     }
 
     /**


### PR DESCRIPTION
Instead of supressing warnings, `array_key_exists` should be used to check if the key is available