### PR TITLE
fix: do not access array key without checking if it exists

### DIFF
--- a/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
+++ b/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
@@ -36,7 +36,7 @@ abstract class AbstractOptionsProvider implements SelectOptionsProviderInterface
     {
         $configuration = $this->loadConfiguration($context, $fieldDefinition);
 
-        if ($default = $configuration[OptionsProviderData::DEFAULT_VALUE]) {
+        if ($default = $configuration[OptionsProviderData::DEFAULT_VALUE] ?? null) {
             return $default;
         }
 


### PR DESCRIPTION
This will prevent errors when running php 8