### PR TITLE
chore: support pimcore x

### DIFF
--- a/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
+++ b/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
@@ -60,7 +60,6 @@ abstract class AbstractOptionsProvider implements SelectOptionsProviderInterface
     protected function loadConfiguration($context, ?Data $fieldDefinition): array
     {
         $cacheKey = self::CACHE_KEY_PREFIX . md5($fieldDefinition ? $fieldDefinition->getOptionsProviderData() : serialize($context));
-        $cacheKey = Tool::getValidCacheKey($cacheKey);
 
         try{
             $this->configuration = Runtime::get($cacheKey);

--- a/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
+++ b/src/Service/Backend/OptionsProvider/AbstractOptionsProvider.php
@@ -6,7 +6,6 @@ use Passioneight\Bundle\PimcoreOptionsProvidersBundle\Constant\OptionsProviderDa
 use Pimcore\Cache\Runtime;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\DynamicOptionsProvider\SelectOptionsProviderInterface;
-use Pimcore\Tool;
 
 abstract class AbstractOptionsProvider implements SelectOptionsProviderInterface
 {


### PR DESCRIPTION
The `getValidCacheKey` method does not exist in Pimcore X anymore. Since it was never actually needed, we can simply remove it.