### PR TITLE
fix(validation): json_last_error false positive

### DIFF
--- a/src/Service/OptionsProvider/AbstractOptionsProvider.php
+++ b/src/Service/OptionsProvider/AbstractOptionsProvider.php
@@ -61,7 +61,7 @@ abstract class AbstractOptionsProvider implements SelectOptionsProviderInterface
 
             Runtime::set($cacheKey, $this->configuration);
 
-            if(json_last_error() !== JSON_ERROR_NONE) {
+            if(\Pimcore::inAdmin() && json_last_error() !== JSON_ERROR_NONE) {
                 throw new \InvalidArgumentException("The options provider data is not valid. Reason: " . json_last_error_msg());
             }
         }


### PR DESCRIPTION
When in frontend, there's a chance that the `json_decode` is called prior to the `loadConfiguration` method. As such, a false positive can occur when checking for `JSON_ERROR_NONE`.